### PR TITLE
feat: Animate keyboard on/off state [Backport f0fe6cdf]

### DIFF
--- a/lawnchair/src/app/lawnchair/SearchBarShowInsetsHandler.kt
+++ b/lawnchair/src/app/lawnchair/SearchBarShowInsetsHandler.kt
@@ -1,0 +1,44 @@
+package app.lawnchair
+
+import android.graphics.Insets
+import android.os.Build
+import android.view.WindowInsetsAnimationControlListener
+import android.view.WindowInsetsAnimationController
+import androidx.annotation.RequiresApi
+import com.android.launcher3.anim.AnimatedFloat
+
+@RequiresApi(Build.VERSION_CODES.R)
+class SearchBarShowInsetsHandler(private val shiftRange: Float) : WindowInsetsAnimationControlListener {
+
+    val progress = AnimatedFloat(this::updateInsets)
+    private var animationController: WindowInsetsAnimationController? = null
+
+    override fun onReady(controller: WindowInsetsAnimationController, types: Int) {
+        animationController = controller
+    }
+
+    override fun onFinished(controller: WindowInsetsAnimationController) {
+        animationController = null
+    }
+
+    override fun onCancelled(controller: WindowInsetsAnimationController?) {
+        animationController = null
+    }
+
+    private fun updateInsets() {
+        val controller = animationController ?: return
+        val shownBottomInset = controller.shownStateInsets.bottom
+        val hiddenBottomInset = controller.hiddenStateInsets.bottom
+        val targetBottomInset = (hiddenBottomInset + progress.value * shiftRange).toInt()
+        val bottomInset = targetBottomInset.coerceIn(hiddenBottomInset, shownBottomInset)
+        controller.setInsetsAndAlpha(
+            Insets.of(0, 0, 0, bottomInset),
+            1f,
+            progress.value,
+        )
+    }
+
+    fun onAnimationEnd() {
+        animationController?.finish(progress.value >= 0.5f)
+    }
+}

--- a/lawnchair/src/app/lawnchair/SearchBarStateHandler.kt
+++ b/lawnchair/src/app/lawnchair/SearchBarStateHandler.kt
@@ -2,6 +2,7 @@ package app.lawnchair
 
 import android.os.CancellationSignal
 import android.view.WindowInsets
+import android.view.animation.Interpolator
 import androidx.core.view.WindowInsetsCompat
 import app.lawnchair.preferences2.PreferenceManager2
 import com.android.app.animation.Interpolators
@@ -40,7 +41,47 @@ class SearchBarStateHandler(private val launcher: LawnchairLauncher) : StateMana
         config: StateAnimationConfig,
         animation: PendingAnimation,
     ) {
-        if (shouldAnimateKeyboard(toState)) {
+        if (shouldAnimateKeyboardShow(toState)) {
+            if (Utilities.ATLEAST_R) {
+                val editText = launcher.appsView.searchUiManager.editText
+                editText?.requestFocus()
+
+                val handler = SearchBarShowInsetsHandler(launcher.allAppsController.shiftRange)
+                val cancellationSignal = CancellationSignal()
+                val windowInsetsController = launcher.appsView.windowInsetsController
+                val interpolator = getKeyboardInterpolator(config.isUserControlled)
+                windowInsetsController?.controlWindowInsetsAnimation(
+                    WindowInsets.Type.ime(),
+                    -1,
+                    interpolator,
+                    cancellationSignal,
+                    handler,
+                )
+                animation.setFloat(
+                    handler.progress,
+                    AnimatedFloat.VALUE,
+                    1f,
+                    interpolator,
+                )
+                animation.addListener(
+                    forEndCallback(
+                        Runnable {
+                            handler.onAnimationEnd()
+                            cancellationSignal.cancel()
+                        },
+                    ),
+                )
+            } else {
+                animation.addListener(
+                    forSuccessCallback {
+                        showKeyboard()
+                    },
+                )
+            }
+            return
+        }
+
+        if (shouldAnimateKeyboardHide(toState)) {
             if (Utilities.ATLEAST_R) {
                 val handler = SearchBarInsetsHandler(launcher.allAppsController.shiftRange)
                 val cancellationSignal = CancellationSignal()
@@ -74,26 +115,34 @@ class SearchBarStateHandler(private val launcher: LawnchairLauncher) : StateMana
                 )
             }
         }
-        if (launcher.isInState(LauncherState.NORMAL) && toState == LauncherState.ALL_APPS) {
-            if (autoShowKeyboard) {
-                val progress = AnimatedFloat()
-                animation.setFloat(progress, AnimatedFloat.VALUE, 1f, Interpolators.LINEAR)
-                animation.addListener(
-                    forSuccessCallback {
-                        if (progress.value > 0.5f) {
-                            showKeyboard()
-                        }
-                    },
-                )
-            }
-        }
     }
 
-    private fun shouldAnimateKeyboard(toState: LauncherState): Boolean {
+    private fun shouldAnimateKeyboardShow(toState: LauncherState): Boolean {
+        if (!autoShowKeyboard || !Utilities.ATLEAST_R) return false
+
+        // If you are in Workspace and going somewhere that isn't AllApps, then false!
+        if (!launcher.isInState(LauncherState.NORMAL) || toState != LauncherState.ALL_APPS) return false
+
+        val insets = launcher.rootView.rootWindowInsets ?: return false
+        val isImeVisible = WindowInsetsCompat.toWindowInsetsCompat(insets).isVisible(WindowInsetsCompat.Type.ime())
+        return !isImeVisible
+    }
+
+    private fun shouldAnimateKeyboardHide(toState: LauncherState): Boolean {
         val windowInsets = launcher.rootView.rootWindowInsets ?: return false
         val rootWindowInsets = WindowInsetsCompat.toWindowInsetsCompat(windowInsets)
         val keyboardVisible = rootWindowInsets.isVisible(WindowInsetsCompat.Type.ime())
+
+        // Keyboard is visible, AND you are in AllApps and going somewhere else that isn't AllApps!
         return keyboardVisible && launcher.isInState(LauncherState.ALL_APPS) && toState != LauncherState.ALL_APPS
+    }
+
+    private fun getKeyboardInterpolator(isUserControlled: Boolean): Interpolator {
+        return if (isUserControlled) {
+            Interpolators.clampToProgress(Interpolators.EMPHASIZED_ACCELERATE, 0.35f, 1.0f)
+        } else {
+            Interpolators.LINEAR
+        }
     }
 
     private fun showKeyboard() {


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

* Fixes #3977

Backport from Bubble Tea (16-dev)
* feat: Animate keyboard on/off state [Backport] | f0fe6cdf
* Modified from patch https://github.com/user-attachments/files/22473693/feat__Animate_keyboard_on_and_off_state.patch

### Reasoning

Animation have been accounted for `16-dev`, not `15-dev`

Really cool keyboard animations transition when going from normal (workspace) to allapps. (But it's all mostly just I told someone I'd do it at some point but I just don't or forget for years but we don't talk about that 😋👍)

This PR listen to IME change and animate keyboard when user has swiped up/down.

### Testing

https://github.com/user-attachments/assets/179b01fe-6f07-4f67-92df-47fc9cb8731c

Testing enviroment:
* 📱 Android 15 (Nothing 3a-series)
* 💺 Lawnchair (16.0 | Bubble Tea) `23092025` (8690f68e+)

### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

:x: **Bug fix** (A non-breaking change that fixes an issue)
✅ **New feature** (A non-breaking change that adds functionality)
:x: **Breaking change** (A fix or feature that would cause existing functionality to not work as expected)
:x: **Refactor** (A code change that neither fixes a bug nor adds a feature)
:x: **Performance** (A code change that improves performance)
:x: **Style** (Code style changes)
:x: **Docs** (Changes to documentation)
:x: **Chore** (Changes to the build process or other tooling)
